### PR TITLE
Ignore windows that don't have titles

### DIFF
--- a/tiling.lua
+++ b/tiling.lua
@@ -70,7 +70,7 @@ end
 function getspace()
   local mainscreen = screen.mainscreen()
   local windows = fnutils.filter(window.visiblewindows(), function(win)
-    return win:screen() == mainscreen and win:isstandard()
+    return win:screen() == mainscreen and win:isstandard() and #win:title() > 0
   end)
 
   fnutils.each(spaces, function(space)


### PR DESCRIPTION
This fixes a bug that can be experienced when
the Adobe Creative Cloud launcher is running
which messes up tiling calculations.

Fixes Issue #2
