### PR TITLE
Feature/gotolayout

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ hotkey.bind(mash, "c", function() tiling.cyclelayout() end)
 hotkey.bind(mash, "j", function() tiling.cycle(1) end)
 hotkey.bind(mash, "k", function() tiling.cycle(-1) end)
 hotkey.bind(mash, "space", function() tiling.promote() end)
+hotkey.bind(mash, "f", function() tiling.gotolayout("fullscreen") end)
 
 -- If you want to set the layouts that are enabled
 tiling.set('layouts', {

--- a/tiling.lua
+++ b/tiling.lua
@@ -110,7 +110,7 @@ function apply(windows, layout)
   layouts[layout](windows)
 end
 
--- return a function that cycles through a table from a starting index
+-- return a function that cycles through an array from a starting index
 function cycle(t, start)
     local i = start
     return function()


### PR DESCRIPTION
Hi

This is a feature to allow for a binding that goes directly to a named layout. E.g:

``` lua
hotkey.bind(mash, "f", function() tiling.gotolayout("fullscreen") end)
```

If you have a number of layouts enabled its alot handier than cycling through layouts to get to a specific one. Also if you're a keystroke counter like me its preferable! Couldn't see an easy way to do this with the existing API. 

Hope you find it a useful addition and if not no worries!

Thanks for the awesome work!

Cheers

Pete
